### PR TITLE
Fix built-in IPC example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Here, as an example, we use the built-in IPC to get an emoji by name in the rend
 ```js
 const {ipcMain: ipc} = require('electron');
 
-ipc.on('get-emoji', async event => {
+ipc.on('get-emoji', async (event, {emojiName}) => {
 	const emoji = await getEmoji(emojiName);
 	event.sender.send('get-emoji-response', emoji);
 });

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Here, as an example, we use the built-in IPC to get an emoji by name in the rend
 ```js
 const {ipcMain: ipc} = require('electron');
 
-ipc.on('get-emoji', async (event, {emojiName}) => {
+ipc.on('get-emoji', async (event, emojiName) => {
 	const emoji = await getEmoji(emojiName);
 	event.sender.send('get-emoji-response', emoji);
 });


### PR DESCRIPTION
I think the built-in IPC example is missing an argument, it's not clear where `emojiName` comes from.