### PR TITLE
Add one more generic type for TypeScript users

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,11 +25,11 @@ export interface MainProcessIpc extends IpcMain {
 	})();
 	```
 	*/
-	callRenderer<T>(
+	callRenderer<T, S>(
 		browserWindow: BrowserWindow,
 		channel: string,
 		data?: T
-	): Promise<unknown>;
+	): Promise<S>;
 
 	/**
 	This method listens for a message from `ipcRenderer.callMain` defined in a renderer process and replies back.
@@ -48,12 +48,12 @@ export interface MainProcessIpc extends IpcMain {
 	});
 	```
 	*/
-	answerRenderer<T>(
+	answerRenderer<T, S>(
 		channel: string,
 		callback: (
-			data: unknown,
+			data: T,
 			browserWindow: BrowserView
-		) => T | PromiseLike<T>
+		) => S | PromiseLike<S>
 	): () => void;
 
 	/**
@@ -86,7 +86,7 @@ export interface RendererProcessIpc extends IpcRenderer {
 	})();
 	```
 	*/
-	callMain<T>(channel: string, data?: T): Promise<unknown>;
+	callMain<T, S>(channel: string, data?: T): Promise<S>;
 
 	/**
 	This method listens for a message from `ipcMain.callRenderer` defined in the main process and replies back.
@@ -105,9 +105,9 @@ export interface RendererProcessIpc extends IpcRenderer {
 	});
 	```
 	*/
-	answerMain<T>(
+	answerMain<T, S>(
 		channel: string,
-		callback: (data?: unknown) => T | PromiseLike<T>
+		callback: (data?: T) => S | PromiseLike<S>
 	): () => void;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,11 +25,11 @@ export interface MainProcessIpc extends IpcMain {
 	})();
 	```
 	*/
-	callRenderer<T, S>(
+	callRenderer<DataType, ReturnType>(
 		browserWindow: BrowserWindow,
 		channel: string,
-		data?: T
-	): Promise<S>;
+		data?: DataType
+	): Promise<ReturnType>;
 
 	/**
 	This method listens for a message from `ipcRenderer.callMain` defined in a renderer process and replies back.
@@ -48,12 +48,12 @@ export interface MainProcessIpc extends IpcMain {
 	});
 	```
 	*/
-	answerRenderer<T, S>(
+	answerRenderer<DataType, ReturnType>(
 		channel: string,
 		callback: (
-			data: T,
+			data: DataType,
 			browserWindow: BrowserView
-		) => S | PromiseLike<S>
+		) => ReturnType | PromiseLike<ReturnType>
 	): () => void;
 
 	/**
@@ -62,7 +62,7 @@ export interface MainProcessIpc extends IpcMain {
 	@param channel - The channel to send the message on.
 	@param data - The data to send to the receiver.
 	*/
-	sendToRenderers<T>(channel: string, data?: T): void;
+	sendToRenderers<DataType>(channel: string, data?: DataType): void;
 }
 
 export interface RendererProcessIpc extends IpcRenderer {
@@ -86,7 +86,7 @@ export interface RendererProcessIpc extends IpcRenderer {
 	})();
 	```
 	*/
-	callMain<T, S>(channel: string, data?: T): Promise<S>;
+	callMain<DataType, ReturnType>(channel: string, data?: DataType): Promise<ReturnType>;
 
 	/**
 	This method listens for a message from `ipcMain.callRenderer` defined in the main process and replies back.
@@ -105,9 +105,9 @@ export interface RendererProcessIpc extends IpcRenderer {
 	});
 	```
 	*/
-	answerMain<T, S>(
+	answerMain<DataType, ReturnType>(
 		channel: string,
-		callback: (data?: T) => S | PromiseLike<S>
+		callback: (data?: DataType) => ReturnType | PromiseLike<ReturnType>
 	): () => void;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export interface MainProcessIpc extends IpcMain {
 	})();
 	```
 	*/
-	callRenderer<DataType, ReturnType>(
+	callRenderer<DataType, ReturnType = unknown>(
 		browserWindow: BrowserWindow,
 		channel: string,
 		data?: DataType
@@ -51,10 +51,10 @@ export interface MainProcessIpc extends IpcMain {
 	})();
 	```
 	*/
-	callFocusedRenderer<T>(
+	callFocusedRenderer<DataType, ReturnType = unknown>(
 		channel: string,
-		data?: T
-	): Promise<unknown>;
+		data?: DataType
+	): Promise<ReturnType>;
 
 	/**
 	This method listens for a message from `ipcRenderer.callMain` defined in a renderer process and replies back.
@@ -73,7 +73,7 @@ export interface MainProcessIpc extends IpcMain {
 	});
 	```
 	*/
-	answerRenderer<DataType, ReturnType>(
+	answerRenderer<DataType, ReturnType = unknown>(
 		channel: string,
 		callback: (
 			data: DataType,
@@ -111,7 +111,7 @@ export interface RendererProcessIpc extends IpcRenderer {
 	})();
 	```
 	*/
-	callMain<DataType, ReturnType>(channel: string, data?: DataType): Promise<ReturnType>;
+	callMain<DataType, ReturnType = unknown>(channel: string, data?: DataType): Promise<ReturnType>;
 
 	/**
 	This method listens for a message from `ipcMain.callRenderer` defined in the main process and replies back.
@@ -130,7 +130,7 @@ export interface RendererProcessIpc extends IpcRenderer {
 	});
 	```
 	*/
-	answerMain<DataType, ReturnType>(
+	answerMain<DataType, ReturnType = unknown>(
 		channel: string,
 		callback: (data?: DataType) => ReturnType | PromiseLike<ReturnType>
 	): () => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,7 +132,7 @@ export interface RendererProcessIpc extends IpcRenderer {
 	*/
 	answerMain<DataType, ReturnType = unknown>(
 		channel: string,
-		callback: (data?: DataType) => ReturnType | PromiseLike<ReturnType>
+		callback: (data: DataType) => ReturnType | PromiseLike<ReturnType>
 	): () => void;
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,6 +13,12 @@ expectType<Promise<unknown>>(
 expectType<Promise<unknown>>(
 	ipcMain.callRenderer(browserWindow!, 'get-emoji', 'unicorn')
 );
+expectType<Promise<unknown>>(
+	ipcMain.callRenderer<string>(browserWindow!, 'get-emoji', 'unicorn')
+);
+expectType<Promise<string>>(
+	ipcMain.callRenderer<string, string>(browserWindow!, 'get-emoji', 'unicorn')
+);
 
 const detachListener = ipcMain.answerRenderer('get-emoji', emojiName => {
 	expectType<unknown>(emojiName);
@@ -22,12 +28,21 @@ ipcMain.answerRenderer('get-emoji', async emojiName => {
 	expectType<unknown>(emojiName);
 	return '🦄';
 });
+ipcMain.answerRenderer<string>('get-emoji', async emojiName => {
+	expectType<string>(emojiName);
+	return '🦄';
+})
+ipcMain.answerRenderer<string, string>('get-emoji', async emojiName => {
+	expectType<string>(emojiName);
+	return '🦄';
+})
 
 expectType<() => void>(detachListener);
 detachListener();
 
 ipcMain.sendToRenderers('get-emoji');
 ipcMain.sendToRenderers('get-emoji', '🦄');
+ipcMain.sendToRenderers<string>('get-emoji', '🦄');
 
 expectError(ipcMain.callMain);
 
@@ -35,6 +50,12 @@ expectError(ipcMain.callMain);
 
 expectType<Promise<unknown>>(
 	ipcRenderer.callMain('get-emoji', 'unicorn')
+);
+expectType<Promise<unknown>>(
+	ipcRenderer.callMain<string>('get-emoji', 'unicorn')
+);
+expectType<Promise<string>>(
+	ipcRenderer.callMain<string, string>('get-emoji', 'unicorn')
 );
 
 const detachListener2 = ipcRenderer.answerMain(
@@ -46,6 +67,14 @@ const detachListener2 = ipcRenderer.answerMain(
 );
 ipcRenderer.answerMain('get-emoji', emojiName => {
 	expectType<unknown>(emojiName);
+	return '🦄';
+});
+ipcRenderer.answerMain<string>('get-emoji', emojiName => {
+	expectType<string | undefined>(emojiName);
+	return '🦄';
+});
+ipcRenderer.answerMain<string, string>('get-emoji', emojiName => {
+	expectType<string | undefined>(emojiName);
 	return '🦄';
 });
 


### PR DESCRIPTION
Adding another generic type to the functions allows developer to easily
specify the data type he wants to receive and return to the emitter.

Closes: https://github.com/sindresorhus/electron-better-ipc/issues/23