### PR TITLE
Improve error messages

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -47,11 +47,10 @@ ipc.callRenderer = (browserWindow, channel, data) => new Promise((resolve, rejec
 	}
 });
 
-ipc.callFocusedRenderer = (...args) => {
+ipc.callFocusedRenderer = async (...args) => {
 	const focusedWindow = BrowserWindow.getFocusedWindow();
-
 	if (!focusedWindow) {
-		return Promise.reject(new Error('No browser window in focus'));
+		throw new Error('No browser window in focus');
 	}
 
 	return ipc.callRenderer(focusedWindow, ...args);

--- a/test/fixture/index.js
+++ b/test/fixture/index.js
@@ -39,5 +39,16 @@ let mainWindow;
 	const answerFromFocusedRenderer = await ipc.callFocusedRenderer('test-focused', 'optional-data');
 	console.log('test-focused:main:answer-from-renderer:', answerFromFocusedRenderer);
 
-	console.log('test-focused:main:answer-from-renderer', answerFromFocusedRenderer);
+	try {
+		await ipc.callRenderer();
+	} catch (error) {
+		console.log('test:main:error-from-renderer:', error.message);
+	}
+
+	try {
+		mainWindow.hide();
+		await ipc.callFocusedRenderer();
+	} catch (error) {
+		console.log('test-focused:main:error-from-renderer:', error.message);
+	}
 })();

--- a/test/fixture/index.js
+++ b/test/fixture/index.js
@@ -37,5 +37,7 @@ let mainWindow;
 	console.log('test:main:answer-from-renderer:', answer);
 
 	const answerFromFocusedRenderer = await ipc.callFocusedRenderer('test-focused', 'optional-data');
+	console.log('test-focused:main:answer-from-renderer:', answerFromFocusedRenderer);
+
 	console.log('test-focused:main:answer-from-renderer', answerFromFocusedRenderer);
 })();

--- a/test/fixture/test.js
+++ b/test/fixture/test.js
@@ -53,7 +53,9 @@ test('main', async t => {
 		'"test:renderer:data-from-main:" "optional-data"',
 		'test-focused:main:answer-from-renderer: test-focused:renderer:answer-data',
 		'test-focused:main:data-from-renderer: optional-data',
+		'test-focused:main:error-from-renderer: No browser window in focus',
 		'test:main:answer-from-renderer: test:renderer:answer-data',
-		'test:main:data-from-renderer: optional-data'
+		'test:main:data-from-renderer: optional-data',
+		'test:main:error-from-renderer: Browser window required'
 	]);
 });

--- a/test/fixture/test.js
+++ b/test/fixture/test.js
@@ -51,7 +51,7 @@ test('main', async t => {
 		'"test-focused:renderer:data-from-main:" "optional-data"',
 		'"test:renderer:answer-from-main:" "test:main:answer"',
 		'"test:renderer:data-from-main:" "optional-data"',
-		'test-focused:main:answer-from-renderer test-focused:renderer:answer-data',
+		'test-focused:main:answer-from-renderer: test-focused:renderer:answer-data',
 		'test-focused:main:data-from-renderer: optional-data',
 		'test:main:answer-from-renderer: test:renderer:answer-data',
 		'test:main:data-from-renderer: optional-data'


### PR DESCRIPTION
Throws more friendly error messages when `call(Focused)Renderer()` are invoked w/o a `BrowserWindow`.

Had a hard time adding tests for this, especially for the focused case (probably due to lacking Electron skills – never actually used it). Adding a simple `t.throws(Async)()` didn't work as `BrowserWindow` is only defined in the `main` process. And with more high-level integration tests it was a pain to reproduce a window not being focused. `blur`-ing the window didn't work (still had focus – even after timeout, awaiting corresponding event etc.).

I ended up hiding the whole window/app. Feel free to remove/edit tests if insufficient or add your own.

Closes #29