### PR TITLE
Add test for #9 (and deal with #16)

### DIFF
--- a/test/fixture/index.js
+++ b/test/fixture/index.js
@@ -19,6 +19,11 @@ ipc.answerRenderer('test-error', async () => {
 	throw new Error('test-error:main:answer');
 });
 
+ipc.answerRenderer('test-concurrency', async data => {
+	console.log('test-concurrency:main:data-from-renderer:', data);
+	return `test-concurrency:main:answer:${data}`;
+});
+
 let mainWindow;
 
 (async () => {

--- a/test/fixture/renderer.js
+++ b/test/fixture/renderer.js
@@ -17,7 +17,15 @@ ipc.callMain('test-error').catch(error => {
 
 ipc.callMain('test-focused', 'optional-data').then(answer => {
 	console.log('test-focused:renderer:answer-from-main:', answer);
-})
+});
+
+ipc.callMain('test-concurrency', 'data-1').then(answer => {
+	console.log('test-concurrency:renderer:answer-from-main-1:', answer);
+});
+
+ipc.callMain('test-concurrency', 'data-2').then(answer => {
+	console.log('test-concurrency:renderer:answer-from-main-2:', answer);
+});
 
 ipc.answerMain('test-focused', data => {
 	console.log('test-focused:renderer:data-from-main:', data);

--- a/test/fixture/test.js
+++ b/test/fixture/test.js
@@ -45,12 +45,16 @@ test('main', async t => {
 	t.deepEqual(logs, [
 		// TODO: The value is missing as Spectron only captures the first argument to `console.log`:
 		// https://github.com/electron/spectron/issues/282
+		'"test-concurrency:renderer:answer-from-main-1:" "test-concurrency:main:answer:data-1"',
+		'"test-concurrency:renderer:answer-from-main-2:" "test-concurrency:main:answer:data-2"',
 		'"test-error:renderer:from-main:error-message" "test-error:main:answer"',
 		'"test-error:renderer:from-main:is-error" true',
 		'"test-focused:renderer:answer-from-main:" "test-focused:main:answer"',
 		'"test-focused:renderer:data-from-main:" "optional-data"',
 		'"test:renderer:answer-from-main:" "test:main:answer"',
 		'"test:renderer:data-from-main:" "optional-data"',
+		'test-concurrency:main:data-from-renderer: data-1',
+		'test-concurrency:main:data-from-renderer: data-2',
 		'test-focused:main:answer-from-renderer: test-focused:renderer:answer-data',
 		'test-focused:main:data-from-renderer: optional-data',
 		'test-focused:main:error-from-renderer: No browser window in focus',


### PR DESCRIPTION
Add a test (confirmed it failed with old behavior) for #9.

I was not able to reproduce #16 by reverting to the old code. However, I think #9 actually "fixed" this as well, as each channel is now unique and thus listeners are not removed by cleaning up another channel. 

On the other hand, at the time this fix was introduced, there was actually only one `callMain/Renderer()` test and therefore the erroneous behavior was not caught. However, as soon as another test was added, this behavior was tested as a bonus. 

What I'm trying to say is: if the implementation was reverted to before #16, but the test suite was kept intact, only one `callMain/Renderer()` test would pass and adding an explicit test for this wouldn't make much sense, IMO.

Closes #12 