### PR TITLE
Properly clean up the event listeners

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -25,16 +25,11 @@ ipc.callRenderer = (browserWindow, channel, data) => new Promise((resolve, rejec
 
 	const onError = (event, error) => {
 		cleanup();
-		reject(error);
+		reject(deserializeError(error));
 	};
 
-	ipc.once(dataChannel, (event, result) => {
-		onData(event, result);
-	});
-
-	ipc.once(errorChannel, (event, error) => {
-		onError(event, deserializeError(error));
-	});
+	ipc.once(dataChannel, onData);
+	ipc.once(errorChannel, onError);
 
 	const completeData = {
 		dataChannel,

--- a/source/renderer.js
+++ b/source/renderer.js
@@ -21,16 +21,11 @@ ipc.callMain = (channel, data) => new Promise((resolve, reject) => {
 
 	const onError = (event, error) => {
 		cleanup();
-		reject(error);
+		reject(deserializeError(error));
 	};
 
-	ipc.once(dataChannel, (event, result) => {
-		onData(event, result);
-	});
-
-	ipc.once(errorChannel, (event, error) => {
-		onError(event, deserializeError(error));
-	});
+	ipc.once(dataChannel, onData);
+	ipc.once(errorChannel, onError);
 
 	const completeData = {
 		dataChannel,

--- a/test/fixture/test.js
+++ b/test/fixture/test.js
@@ -58,4 +58,11 @@ test('main', async t => {
 		'test:main:data-from-renderer: optional-data',
 		'test:main:error-from-renderer: Browser window required'
 	]);
+
+	const {ipcRenderer, remote: {ipcMain}} = app.electron;
+	const countDataAndErrorListeners = async emitter =>
+		(await emitter.eventNames()).filter(name => /(data|error)-channel/.test(name)).length;
+
+	t.is(await countDataAndErrorListeners(ipcMain), 0);
+	t.is(await countDataAndErrorListeners(ipcRenderer), 0);
 });


### PR DESCRIPTION
Extracted as unrelated change from #31.

Fix memory leak where listeners are not being properly removed + add accompanying test.

Note about test: I've confirmed that the test for `ipcMain` failed before fix, but `ipcRenderer` reported 0 listeners via `spectron` even though I've confirmed by logging in the implementation that is not the case. Moreover, all the send channel listeners are definitely still registered (as they need to be explicitly removed). 

I think `spectron` is to blame here, but I'm not sure as I'm not deeply familiar with `electron` altogether. Maybe both can't run in the right context in the same test?