### PR TITLE
Fix TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {BrowserWindow, BrowserView, IpcMain, IpcRenderer} from 'electron';
+import {BrowserWindow, IpcMain, IpcRenderer} from 'electron';
 
 export interface MainProcessIpc extends IpcMain {
 	/**
@@ -77,7 +77,7 @@ export interface MainProcessIpc extends IpcMain {
 		channel: string,
 		callback: (
 			data: DataType,
-			browserWindow: BrowserView
+			browserWindow: BrowserWindow
 		) => ReturnType | PromiseLike<ReturnType>
 	): () => void;
 
@@ -104,7 +104,7 @@ export interface MainProcessIpc extends IpcMain {
 		channel: string,
 		callback: (
 			data: DataType,
-			browserWindow: BrowserView
+			browserWindow: BrowserWindow
 		) => ReturnType | PromiseLike<ReturnType>
 	): () => void;
 


### PR DESCRIPTION
I noticed that the type there is BrowserView when the electron api says that the `fromWebContents` method returns a BrowserWindow (https://www.electronjs.org/docs/api/browser-window#browserwindowfromwebcontentswebcontents)

I think the readme is correct, the type was just off