### PR TITLE
Upgrade Electron

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,26 +1,26 @@
 /// <reference lib="dom"/>
 import {expectType, expectError} from 'tsd';
 import {BrowserWindow} from 'electron';
-import {ipcMain, ipcRenderer} from '.';
+import {ipcMain, ipcRenderer} from './index.js';
 
-const browserWindow = BrowserWindow.getFocusedWindow();
+const browserWindow = BrowserWindow.getFocusedWindow()!;
 
-// ipcMain
+// IpcMain
 
 expectType<Promise<unknown>>(
-	ipcMain.callRenderer(browserWindow!, 'get-emoji')
+	ipcMain.callRenderer(browserWindow, 'get-emoji')
 );
 expectType<Promise<unknown>>(
-	ipcMain.callRenderer(browserWindow!, 'get-emoji', 'unicorn')
+	ipcMain.callRenderer(browserWindow, 'get-emoji', 'unicorn')
 );
 expectType<Promise<unknown>>(
-	ipcMain.callRenderer<string>(browserWindow!, 'get-emoji', 'unicorn')
+	ipcMain.callRenderer<string>(browserWindow, 'get-emoji', 'unicorn')
 );
 expectType<Promise<string>>(
-	ipcMain.callRenderer<string, string>(browserWindow!, 'get-emoji', 'unicorn')
+	ipcMain.callRenderer<string, string>(browserWindow, 'get-emoji', 'unicorn')
 );
 expectType<Promise<string>>(
-	ipcMain.callRenderer(browserWindow!, 'get-emoji', 'unicorn')
+	ipcMain.callRenderer(browserWindow, 'get-emoji', 'unicorn')
 );
 
 const detachListener = ipcMain.answerRenderer('get-emoji', emojiName => {
@@ -39,11 +39,10 @@ ipcMain.answerRenderer<string, string>('get-emoji', async emojiName => {
 	expectType<string>(emojiName);
 	return '🦄';
 });
-ipcMain.answerRenderer<string, string>(browserWindow!, 'get-emoji', async emojiName => {
+ipcMain.answerRenderer<string, string>(browserWindow, 'get-emoji', async emojiName => {
 	expectType<string>(emojiName);
 	return '🦄';
 });
-
 
 expectType<() => void>(detachListener);
 detachListener();
@@ -54,7 +53,7 @@ ipcMain.sendToRenderers<string>('get-emoji', '🦄');
 
 expectError(ipcMain.callMain);
 
-// ipcRenderer
+// IpcRenderer
 
 expectType<Promise<unknown>>(
 	ipcRenderer.callMain('get-emoji', 'unicorn')

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	"devDependencies": {
 		"@electron/remote": "^1.1.0",
 		"ava": "^2.2.0",
-		"electron": "^12",
+		"electron": "^10",
 		"execa": "^4.0.0",
 		"spectron": "^8.0.0",
 		"tsd": "^0.14",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,13 @@
 		"serialize-error": "^5.0.0"
 	},
 	"devDependencies": {
+		"@electron/remote": "^1.1.0",
 		"ava": "^2.2.0",
-		"electron": "^6.0.2",
+		"electron": "^12",
 		"execa": "^4.0.0",
 		"spectron": "^8.0.0",
-		"tsd": "^0.11.0",
-		"xo": "^0.25.3"
+		"tsd": "^0.14",
+		"xo": "^0.38"
 	},
 	"xo": {
 		"envs": [

--- a/source/renderer.js
+++ b/source/renderer.js
@@ -1,5 +1,6 @@
 'use strict';
 const electron = require('electron');
+const {getCurrentWindow} = require('@electron/remote');
 const {serializeError, deserializeError} = require('serialize-error');
 const util = require('./util');
 
@@ -37,7 +38,7 @@ ipc.callMain = (channel, data) => new Promise((resolve, reject) => {
 });
 
 ipc.answerMain = (channel, callback) => {
-	const browserWindow = electron.remote.getCurrentWindow();
+	const browserWindow = getCurrentWindow();
 	const sendChannel = util.getRendererSendChannel(browserWindow.id, channel);
 
 	const listener = async (event, data) => {


### PR DESCRIPTION
Upgrade Electron to v12 which would require the move to @electron/remote. Minor changes were made in the code since there is only one place where it is really used. XO and tsd are upgraded to the latest version. There where some errors in the ts declaration file tests because of that so there were some minor changes mate to them but functionally nothing is changed.