### PR TITLE
Fix Electron 12 compatibility

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,26 +1,26 @@
 /// <reference lib="dom"/>
 import {expectType, expectError} from 'tsd';
 import {BrowserWindow} from 'electron';
-import {ipcMain, ipcRenderer} from '.';
+import {ipcMain, ipcRenderer} from './index.js';
 
-const browserWindow = BrowserWindow.getFocusedWindow();
+const browserWindow = BrowserWindow.getFocusedWindow()!;
 
-// ipcMain
+// IpcMain
 
 expectType<Promise<unknown>>(
-	ipcMain.callRenderer(browserWindow!, 'get-emoji')
+	ipcMain.callRenderer(browserWindow, 'get-emoji')
 );
 expectType<Promise<unknown>>(
-	ipcMain.callRenderer(browserWindow!, 'get-emoji', 'unicorn')
+	ipcMain.callRenderer(browserWindow, 'get-emoji', 'unicorn')
 );
 expectType<Promise<unknown>>(
-	ipcMain.callRenderer<string>(browserWindow!, 'get-emoji', 'unicorn')
+	ipcMain.callRenderer<string>(browserWindow, 'get-emoji', 'unicorn')
 );
 expectType<Promise<string>>(
-	ipcMain.callRenderer<string, string>(browserWindow!, 'get-emoji', 'unicorn')
+	ipcMain.callRenderer<string, string>(browserWindow, 'get-emoji', 'unicorn')
 );
 expectType<Promise<string>>(
-	ipcMain.callRenderer(browserWindow!, 'get-emoji', 'unicorn')
+	ipcMain.callRenderer(browserWindow, 'get-emoji', 'unicorn')
 );
 
 const detachListener = ipcMain.answerRenderer('get-emoji', emojiName => {
@@ -39,11 +39,10 @@ ipcMain.answerRenderer<string, string>('get-emoji', async emojiName => {
 	expectType<string>(emojiName);
 	return '🦄';
 });
-ipcMain.answerRenderer<string, string>(browserWindow!, 'get-emoji', async emojiName => {
+ipcMain.answerRenderer<string, string>(browserWindow, 'get-emoji', async emojiName => {
 	expectType<string>(emojiName);
 	return '🦄';
 });
-
 
 expectType<() => void>(detachListener);
 detachListener();
@@ -54,7 +53,7 @@ ipcMain.sendToRenderers<string>('get-emoji', '🦄');
 
 expectError(ipcMain.callMain);
 
-// ipcRenderer
+// IpcRenderer
 
 expectType<Promise<unknown>>(
 	ipcRenderer.callMain('get-emoji', 'unicorn')

--- a/package.json
+++ b/package.json
@@ -40,11 +40,12 @@
 	},
 	"devDependencies": {
 		"ava": "^2.2.0",
-		"electron": "^6.0.2",
+		"electron": "^10",
 		"execa": "^4.0.0",
-		"spectron": "^8.0.0",
-		"tsd": "^0.11.0",
-		"xo": "^0.25.3"
+		"spectron": "^12",
+		"synchronized-promise": "^0.3.1",
+		"tsd": "^0.14",
+		"xo": "^0.38"
 	},
 	"xo": {
 		"envs": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"scripts": {
 		"test": "xo && tsd",
-		"test-with-spectron": "xo && (cd test/fixture && ava) && tsd"
+		"test-with-app": "xo && (cd test/fixture && ava) && tsd"
 	},
 	"files": [
 		"index.js",
@@ -42,8 +42,6 @@
 		"ava": "^2.2.0",
 		"electron": "^10",
 		"execa": "^4.0.0",
-		"spectron": "^12",
-		"synchronized-promise": "^0.3.1",
 		"tsd": "^0.14",
 		"xo": "^0.38"
 	},

--- a/source/main.js
+++ b/source/main.js
@@ -6,6 +6,10 @@ const util = require('./util');
 const {ipcMain, BrowserWindow} = electron;
 const ipc = Object.create(ipcMain || {});
 
+ipcMain.handle(util.currentWindowChannel, event => {
+	return event.sender.id;
+});
+
 ipc.callRenderer = (browserWindow, channel, data) => new Promise((resolve, reject) => {
 	if (!browserWindow) {
 		throw new Error('Browser window required');

--- a/source/renderer.js
+++ b/source/renderer.js
@@ -1,6 +1,7 @@
 'use strict';
 const electron = require('electron');
 const {serializeError, deserializeError} = require('serialize-error');
+const sp = require('synchronized-promise');
 const util = require('./util');
 
 const {ipcRenderer} = electron;
@@ -37,8 +38,8 @@ ipc.callMain = (channel, data) => new Promise((resolve, reject) => {
 });
 
 ipc.answerMain = (channel, callback) => {
-	const browserWindow = electron.remote.getCurrentWindow();
-	const sendChannel = util.getRendererSendChannel(browserWindow.id, channel);
+	const browserWindowId = sp(ipcRenderer.invoke)(util.currentWindowChannel);
+	const sendChannel = util.getRendererSendChannel(browserWindowId, channel);
 
 	const listener = async (event, data) => {
 		const {dataChannel, errorChannel, userData} = data;

--- a/source/renderer.js
+++ b/source/renderer.js
@@ -1,7 +1,6 @@
 'use strict';
 const electron = require('electron');
 const {serializeError, deserializeError} = require('serialize-error');
-const sp = require('synchronized-promise');
 const util = require('./util');
 
 const {ipcRenderer} = electron;
@@ -15,12 +14,12 @@ ipc.callMain = (channel, data) => new Promise((resolve, reject) => {
 		ipc.off(errorChannel, onError);
 	};
 
-	const onData = (event, result) => {
+	const onData = (_event, result) => {
 		cleanup();
 		resolve(result);
 	};
 
-	const onError = (event, error) => {
+	const onError = (_event, error) => {
 		cleanup();
 		reject(deserializeError(error));
 	};
@@ -38,10 +37,9 @@ ipc.callMain = (channel, data) => new Promise((resolve, reject) => {
 });
 
 ipc.answerMain = (channel, callback) => {
-	const browserWindowId = sp(ipcRenderer.invoke)(util.currentWindowChannel);
-	const sendChannel = util.getRendererSendChannel(browserWindowId, channel);
+	const sendChannel = util.getRendererSendChannel(channel);
 
-	const listener = async (event, data) => {
+	const listener = async (_event, data) => {
 		const {dataChannel, errorChannel, userData} = data;
 
 		try {

--- a/source/util.js
+++ b/source/util.js
@@ -3,7 +3,7 @@
 const getUniqueId = () => `${Date.now()}-${Math.random()}`;
 
 const getSendChannel = channel => `%better-ipc-send-channel-${channel}`;
-const getRendererSendChannel = (windowId, channel) => `%better-ipc-send-channel-${windowId}-${channel}`;
+const getRendererSendChannel = channel => `%better-ipc-send-channel-${channel}`;
 
 module.exports.currentWindowChannel = '%better-ipc-current-window';
 
@@ -19,11 +19,11 @@ module.exports.getResponseChannels = channel => {
 	};
 };
 
-module.exports.getRendererResponseChannels = (windowId, channel) => {
+module.exports.getRendererResponseChannels = channel => {
 	const id = getUniqueId();
 	return {
-		sendChannel: getRendererSendChannel(windowId, channel),
-		dataChannel: `%better-ipc-response-data-channel-${windowId}-${channel}-${id}`,
-		errorChannel: `%better-ipc-response-error-channel-${windowId}-${channel}-${id}`
+		sendChannel: getRendererSendChannel(channel),
+		dataChannel: `%better-ipc-response-data-channel-${channel}-${id}`,
+		errorChannel: `%better-ipc-response-error-channel-${channel}-${id}`
 	};
 };

--- a/source/util.js
+++ b/source/util.js
@@ -5,6 +5,8 @@ const getUniqueId = () => `${Date.now()}-${Math.random()}`;
 const getSendChannel = channel => `%better-ipc-send-channel-${channel}`;
 const getRendererSendChannel = (windowId, channel) => `%better-ipc-send-channel-${windowId}-${channel}`;
 
+module.exports.currentWindowChannel = '%better-ipc-current-window';
+
 module.exports.getSendChannel = getSendChannel;
 module.exports.getRendererSendChannel = getRendererSendChannel;
 

--- a/test/fixture/index.js
+++ b/test/fixture/index.js
@@ -1,9 +1,15 @@
 'use strict';
 const path = require('path');
-const {app, BrowserWindow} = require('electron');
+const {app, BrowserWindow, ipcMain} = require('electron');
 const {ipcMain: ipc} = require('../..');
+const {countDataAndErrorListeners} = require('./util');
 
-process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = true;
+let countOfLogs = 0;
+
+ipcMain.on('log', (_event, log) => {
+	console.log(log);
+	countOfLogs++;
+});
 
 ipc.answerRenderer('test', async data => {
 	console.log('test:main:data-from-renderer:', data);
@@ -24,14 +30,10 @@ ipc.answerRenderer('test-concurrency', async data => {
 	return `test-concurrency:main:answer:${data}`;
 });
 
-let mainWindow;
-
 (async () => {
 	await app.whenReady();
 
-	mainWindow = new BrowserWindow({
-		// Why? See below:
-		// https://github.com/electron-userland/spectron/issues/174#issuecomment-525540776
+	const mainWindow = new BrowserWindow({
 		webPreferences: {
 			nodeIntegration: true
 		}
@@ -57,9 +59,22 @@ let mainWindow;
 	}
 
 	try {
+		mainWindow.blur();
 		mainWindow.hide();
 		await ipc.callFocusedRenderer();
 	} catch (error) {
 		console.log('test-focused:main:error-from-renderer:', error.message);
 	}
+
+	// Get the count of listeners from rednerer
+	mainWindow.webContents.send('count');
+
+	console.log('test-count-main-listeners:', countDataAndErrorListeners(ipcMain));
+
+	// Wait to get all logs from renderer and then quit the app
+	setInterval(() => {
+		if (countOfLogs === 10) {
+			app.quit();
+		}
+	}, 100);
 })();

--- a/test/fixture/index.js
+++ b/test/fixture/index.js
@@ -66,12 +66,12 @@ ipc.answerRenderer('test-concurrency', async data => {
 		console.log('test-focused:main:error-from-renderer:', error.message);
 	}
 
-	// Get the count of listeners from rednerer
+	// Get the count of listeners from the renderer.
 	mainWindow.webContents.send('count');
 
 	console.log('test-count-main-listeners:', countDataAndErrorListeners(ipcMain));
 
-	// Wait to get all logs from renderer and then quit the app
+	// Wait to get all logs from the renderer and then quit the app.
 	setInterval(() => {
 		if (countOfLogs === 10) {
 			app.quit();

--- a/test/fixture/renderer.js
+++ b/test/fixture/renderer.js
@@ -1,37 +1,41 @@
 'use strict';
+const {ipcRenderer} = require('electron');
 const {ipcRenderer: ipc} = require('../..');
+const {countDataAndErrorListeners} = require('./util');
+
+ipcRenderer.once('count', () => ipcRenderer.send('log', 'test-count-renderer-listeners: ' + countDataAndErrorListeners(ipcRenderer)));
 
 ipc.callMain('test', 'optional-data').then(answer => {
-	console.log('test:renderer:answer-from-main:', answer);
+	ipcRenderer.send('log', 'test:renderer:answer-from-main: ' + answer);
 });
 
 ipc.answerMain('test', data => {
-	console.log('test:renderer:data-from-main:', data);
+	ipcRenderer.send('log', 'test:renderer:data-from-main: ' + data);
 	return 'test:renderer:answer-data';
 });
 
 ipc.callMain('test-error').catch(error => {
-	console.log('test-error:renderer:from-main:is-error', error instanceof Error);
-	console.log('test-error:renderer:from-main:error-message', error.message);
+	ipcRenderer.send('log', 'test-error:renderer:from-main:is-error ' + (error instanceof Error));
+	ipcRenderer.send('log', 'test-error:renderer:from-main:error-message ' + error.message);
 });
 
 ipc.callMain('test-focused', 'optional-data').then(answer => {
-	console.log('test-focused:renderer:answer-from-main:', answer);
+	ipcRenderer.send('log', 'test-focused:renderer:answer-from-main: ' + answer);
 });
 
 ipc.callMain('test-concurrency', 'data-1').then(answer => {
-	console.log('test-concurrency:renderer:answer-from-main-1:', answer);
+	ipcRenderer.send('log', 'test-concurrency:renderer:answer-from-main-1: ' + answer);
 });
 
 ipc.callMain('test-concurrency', 'data-2').then(answer => {
-	console.log('test-concurrency:renderer:answer-from-main-2:', answer);
+	ipcRenderer.send('log', 'test-concurrency:renderer:answer-from-main-2: ' + answer);
 });
 
 ipc.answerMain('test-focused', data => {
-	console.log('test-focused:renderer:data-from-main:', data);
+	ipcRenderer.send('log', 'test-focused:renderer:data-from-main: ' + data);
 	return 'test-focused:renderer:answer-data';
 });
 
 ipc.callMain('test-specific-window', 'data-1').then(answer => {
-	console.log('test-specific-window:renderer:answer-from-main:', answer);
+	ipcRenderer.send('log', 'test-specific-window:renderer:answer-from-main: ' + answer);
 });

--- a/test/fixture/test.js
+++ b/test/fixture/test.js
@@ -65,6 +65,8 @@ test('main', async t => {
 		'test:main:error-from-renderer: Browser window required'
 	]);
 
+	// This part of the test will be fixed (remote will be removed) but first I need to figure
+	// out how to run the test in the first place.
 	const {ipcRenderer, remote: {ipcMain}} = app.electron;
 	const countDataAndErrorListeners = async emitter =>
 		(await emitter.eventNames()).filter(name => /(data|error)-channel/.test(name)).length;

--- a/test/fixture/test.js
+++ b/test/fixture/test.js
@@ -1,76 +1,46 @@
 import electron from 'electron';
-import {serial as test} from 'ava';
-import {Application} from 'spectron';
+import test from 'ava';
+import execa from 'execa';
 
-test.beforeEach(async t => {
-	t.context.app = new Application({
-		path: electron,
-		args: ['.']
+const run = async file => {
+	const {stdout} = await execa(electron, [file], {
+		timeout: 10000
 	});
-});
 
-test.afterEach(t => {
-	return t.context.app.stop();
-});
+	return stdout.trim();
+};
 
 test('main', async t => {
-	const {app} = t.context;
-	await app.start();
-	await app.client.waitUntilWindowLoaded();
+	const stdout = await run('index.js');
 
-	const [mainLogs, rendererLogs] = await Promise.all([
-		app.client.getMainProcessLogs(),
-		app.client.getRenderProcessLogs()
-	]);
-
-	let logs = [
-		...mainLogs,
-		// TODO: We have to clean the message because of:
-		// https://github.com/electron/spectron/issues/283
-		...rendererLogs.map(x => x.message.replace(/[^"]+/, ''))
-	].sort();
-
-	// More useless cleanup because Spectron sucks
-	logs = logs.filter(x =>
-		!x.startsWith('DevTools listening') &&
-		!x.includes(':CONSOLE(') &&
-		// Cannot match like this one: [79915:0924/100744.171411:INFO:CONSOLE(14)]
-		// !/^\[.*:CONSOLE\(\d\)\]/.test(x) &&
-		x !== '' &&
-		x !== 'Please protect ports used by ChromeDriver and related test frameworks to prevent access by malicious code.'
-	);
+	const logs = [
+		...stdout.split('\n')
+	].filter(x =>
+		x !== ''
+	).sort();
 
 	console.log(logs);
 
 	t.deepEqual(logs, [
-		// TODO: The value is missing as Spectron only captures the first argument to `console.log`:
-		// https://github.com/electron/spectron/issues/282
-		'"test-concurrency:renderer:answer-from-main-1:" "test-concurrency:main:answer:data-1"',
-		'"test-concurrency:renderer:answer-from-main-2:" "test-concurrency:main:answer:data-2"',
-		'"test-error:renderer:from-main:error-message" "test-error:main:answer"',
-		'"test-error:renderer:from-main:is-error" true',
-		'"test-focused:renderer:answer-from-main:" "test-focused:main:answer"',
-		'"test-focused:renderer:data-from-main:" "optional-data"',
-		'"test-specific-window:renderer:answer-from-main:" "test-specific-window:main:answer:data-1"',
-		'"test:renderer:answer-from-main:" "test:main:answer"',
-		'"test:renderer:data-from-main:" "optional-data"',
 		'test-concurrency:main:data-from-renderer: data-1',
 		'test-concurrency:main:data-from-renderer: data-2',
+		'test-concurrency:renderer:answer-from-main-1: test-concurrency:main:answer:data-1',
+		'test-concurrency:renderer:answer-from-main-2: test-concurrency:main:answer:data-2',
+		'test-count-main-listeners: 0',
+		'test-count-renderer-listeners: 0',
+		'test-error:renderer:from-main:error-message test-error:main:answer',
+		'test-error:renderer:from-main:is-error true',
 		'test-focused:main:answer-from-renderer: test-focused:renderer:answer-data',
 		'test-focused:main:data-from-renderer: optional-data',
 		'test-focused:main:error-from-renderer: No browser window in focus',
+		'test-focused:renderer:answer-from-main: test-focused:main:answer',
+		'test-focused:renderer:data-from-main: optional-data',
 		'test-specific-window:main:data-from-renderer: data-1',
+		'test-specific-window:renderer:answer-from-main: test-specific-window:main:answer:data-1',
 		'test:main:answer-from-renderer: test:renderer:answer-data',
 		'test:main:data-from-renderer: optional-data',
-		'test:main:error-from-renderer: Browser window required'
+		'test:main:error-from-renderer: Browser window required',
+		'test:renderer:answer-from-main: test:main:answer',
+		'test:renderer:data-from-main: optional-data'
 	]);
-
-	// This part of the test will be fixed (remote will be removed) but first I need to figure
-	// out how to run the test in the first place.
-	const {ipcRenderer, remote: {ipcMain}} = app.electron;
-	const countDataAndErrorListeners = async emitter =>
-		(await emitter.eventNames()).filter(name => /(data|error)-channel/.test(name)).length;
-
-	t.is(await countDataAndErrorListeners(ipcMain), 0);
-	t.is(await countDataAndErrorListeners(ipcRenderer), 0);
 });

--- a/test/fixture/util.js
+++ b/test/fixture/util.js
@@ -1,0 +1,4 @@
+const countDataAndErrorListeners = emitter =>
+	emitter.eventNames().filter(name => /(data|error)-channel/.test(name)).length;
+
+module.exports.countDataAndErrorListeners = countDataAndErrorListeners;


### PR DESCRIPTION
This removes use of Electron remote so library would be compatible with Electron 12+. It's done by creating an invoke handler which will return window id so the answerMain listener can be crated for that specific window.

Maybe a better solution would be to rewrite the architecture and remove the use of window id all together. I'm not completely sure why it is done but to me it seems like when ipc call is sent to a browser window it's sent to that window only even if there is some other window listening on the same channel. Adding window id to the channel name look a little redundant. Is there some reason it's done that way or could it be removed and that would remove the requirement for getting the window id in the renderer process.

One big problem right now is the `test-with-spectron` test because I get an error when trying to run it on a newer version of electron and spectron.
```
1 test failed

  main

  /home/dusan/Dev/electron-better-ipc/node_modules/webdriver/build/utils.js:34

  Rejected promise returned by test. Reason:

  Error {
    message: `Failed to create session.␊
    Timeout awaiting 'request' for 10000ms`,
  }

  Object.startWebDriverSession (/home/dusan/Dev/electron-better-ipc/node_modules/webdriver/build/utils.js:34:15)
  Function.newSession (/home/dusan/Dev/electron-better-ipc/node_modules/webdriver/build/index.js:35:45)
  Object.exports.remote (/home/dusan/Dev/electron-better-ipc/node_modules/webdriverio/build/index.js:53:22)
```
It seems like webdriver can't connect to chromedriver for some odd reason and a request times out. This happens on newer version of electron (10+) but on older version I get some other odd errors and Spectron doesn't work either. I'm really not that experienced with Spectron and I did what research I could. I tried all proposed solutions from Spectron issues page and none worked. It would be good if I can get some feedback on this to see at least if it is platform specific (I run Linux).