### PR TITLE
Fix problem with multiple `callMain` calls

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -14,8 +14,8 @@ ipc.callRenderer = (browserWindow, channel, data) => new Promise((resolve, rejec
 	const {sendChannel, dataChannel, errorChannel} = util.getRendererResponseChannels(channel);
 
 	const cleanup = () => {
-		ipc.off(dataChannel, onData);
-		ipc.off(errorChannel, onError);
+		ipcMain.off(dataChannel, onData);
+		ipcMain.off(errorChannel, onError);
 	};
 
 	const onData = (event, result) => {
@@ -34,8 +34,8 @@ ipc.callRenderer = (browserWindow, channel, data) => new Promise((resolve, rejec
 		}
 	};
 
-	ipc.on(dataChannel, onData);
-	ipc.on(errorChannel, onError);
+	ipcMain.on(dataChannel, onData);
+	ipcMain.on(errorChannel, onError);
 
 	const completeData = {
 		dataChannel,
@@ -99,10 +99,10 @@ ipc.answerRenderer = (browserWindowOrChannel, channelOrCallback, callbackOrNothi
 		}
 	};
 
-	ipc.on(sendChannel, listener);
+	ipcMain.on(sendChannel, listener);
 
 	return () => {
-		ipc.off(sendChannel, listener);
+		ipcMain.off(sendChannel, listener);
 	};
 };
 

--- a/source/renderer.js
+++ b/source/renderer.js
@@ -10,8 +10,8 @@ ipc.callMain = (channel, data) => new Promise((resolve, reject) => {
 	const {sendChannel, dataChannel, errorChannel} = util.getResponseChannels(channel);
 
 	const cleanup = () => {
-		ipc.off(dataChannel, onData);
-		ipc.off(errorChannel, onError);
+		ipcRenderer.off(dataChannel, onData);
+		ipcRenderer.off(errorChannel, onError);
 	};
 
 	const onData = (_event, result) => {
@@ -24,8 +24,8 @@ ipc.callMain = (channel, data) => new Promise((resolve, reject) => {
 		reject(deserializeError(error));
 	};
 
-	ipc.once(dataChannel, onData);
-	ipc.once(errorChannel, onError);
+	ipcRenderer.once(dataChannel, onData);
+	ipcRenderer.once(errorChannel, onError);
 
 	const completeData = {
 		dataChannel,
@@ -33,7 +33,7 @@ ipc.callMain = (channel, data) => new Promise((resolve, reject) => {
 		userData: data
 	};
 
-	ipc.send(sendChannel, completeData);
+	ipcRenderer.send(sendChannel, completeData);
 });
 
 ipc.answerMain = (channel, callback) => {
@@ -43,16 +43,16 @@ ipc.answerMain = (channel, callback) => {
 		const {dataChannel, errorChannel, userData} = data;
 
 		try {
-			ipc.send(dataChannel, await callback(userData));
+			ipcRenderer.send(dataChannel, await callback(userData));
 		} catch (error) {
-			ipc.send(errorChannel, serializeError(error));
+			ipcRenderer.send(errorChannel, serializeError(error));
 		}
 	};
 
-	ipc.on(sendChannel, listener);
+	ipcRenderer.on(sendChannel, listener);
 
 	return () => {
-		ipc.off(sendChannel, listener);
+		ipcRenderer.off(sendChannel, listener);
 	};
 };
 


### PR DESCRIPTION
Fixes #35 .
This patch replace the calls to ipc.on and ipc.off with calls to prototypes of ipc object, so that the callback will be added to the right place and then handled properly.